### PR TITLE
Fix for issue #1

### DIFF
--- a/guard-rake.gemspec
+++ b/guard-rake.gemspec
@@ -4,7 +4,7 @@ require 'guard/version'
 
 Gem::Specification.new do |s|
   s.name        = 'guard-rake'
-  s.version     = Guard::Rake::VERSION
+  s.version     = Guard::RakeVersion::VERSION
   s.authors     = ['Scott Barron']
   s.email       = ['scott@elitists.net']
   s.homepage    = 'http://github.com/rubyist/guard-rake'

--- a/lib/guard/version.rb
+++ b/lib/guard/version.rb
@@ -1,5 +1,5 @@
 module Guard
-  module Rake
+  module RakeVersion
     VERSION = "0.0.1"
   end
 end


### PR DESCRIPTION
https://github.com/rubyist/guard-rake/issues/1

This is to avoid conflict with Guard::Rake class definition. I don't know
the purpose of this file, but from other guard plugins I take that
plugin name + "Version" is the convention.
