### PR TITLE
Added reenable for all tasks, changed execute to invoke.

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -40,7 +40,8 @@ module Guard
 
     def run_rake_task
       UI.info "running #{@task}"
-      ::Rake::Task[@task].execute
+      ::Rake::Task.tasks.each { |t| t.reenable }
+      ::Rake::Task[@task].invoke
     end
   end
 end


### PR DESCRIPTION
Changed Guard::Rake#run_rake_task to re-enable all tasks in Rake, and then run invoke instead of execute. This gets around a problem we had where dependencies weren't being followed after being run. Once dependencies have been re-enabled, it seems invoke is the right way to run the necessary tasks again.
