### PR TITLE
Work with rake 0.8.7 + run on start by default

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -9,7 +9,8 @@ module Guard
     def initialize(watchers=[], options={})
       super
       @options = {
-        run_on_all: true
+        :run_on_start => true,
+        :run_on_all => true
       }.update(options)
       @task = @options[:task]
     end
@@ -17,6 +18,7 @@ module Guard
     def start
       UI.info "Starting guard-rake #{@task}"
       load 'Rakefile'
+      run_all if @options[:run_on_start]
       true
     end
 


### PR DESCRIPTION
Rake::DSL not exists in rake 0.8.7 so include it only if present.
Added option to run task on start, by default set to true.
