### PR TITLE
Use Rake methods to initialize and load Rakefile

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -16,7 +16,8 @@ module Guard
 
     def start
       UI.info "Starting guard-rake #{@task}"
-      load 'Rakefile'
+      ::Rake.application.init
+      ::Rake.application.load_rakefile
       true
     end
 


### PR DESCRIPTION
Rake has a convention of automatically loading tasks defined in any
*.rake files under the ./rakelib directory. This change uses Rake's internal
mechanism for loading a Rakefile which respects this convention.
