### PR TITLE
Adds support for passing the modified paths as arguments to the rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ the watched files change.
 :task => 'doit'              # name of the task to be executed, required
 :run_on_all => false         # runs when the 'run_all' signal is received from Guard (enter is pressed), default: true
 :run_on_start => true        # runs when guard is started, default: true
+:run_each => true            # runs rake task with each modified path as the argument, default: true
+:no_args => true             # runs rake task without passing arguments to the rake task, default: true
 ```
 
 ## Development

--- a/lib/guard/rake/version.rb
+++ b/lib/guard/rake/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module RakeVersion
-    VERSION = "0.0.7"
+    VERSION = "0.0.7.1"
   end
 end


### PR DESCRIPTION
Hi,

I suppose this is the opposite of [using guard programmatically in a Rake task](https://github.com/guard/guard/wiki/Guard-Cookbook).

I set the new options' defaults to not impact current users of guard-rake. Their interaction is a bit confusing though, let me know if I should be more thorough in the README.

That said, the Guard-Cookbook way may be the preferred approach.

Cheers
