### PR TITLE
Pass changed paths to rake task

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -2,7 +2,6 @@ require 'guard'
 require 'guard/guard'
 require 'guard/version'
 require 'rake'
-require 'debugger'
 
 module Guard
   class Rake < Guard


### PR DESCRIPTION
For my use case, I needed access to the modified file names to make intelligent decisions about what to do (asset compilation for my mobile pipeline).  I've made a small change to pass the observed path through to the rake task.

I don't believe it will break anyone already using the gem.
