### PR TITLE
add a new option, :failure_ok, to tolerate failures from rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ the watched files change.
 :task => 'doit'              # name of the task to be executed, required
 :run_on_all => false         # runs when the 'run_all' signal is received from Guard (enter is pressed), default: true
 :run_on_start => true        # runs when guard is started, default: true
+:failure_ok => false         # if the rake task aborts or fails, does not raise to guard itself.
 ```
 
 ## Development

--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -9,7 +9,8 @@ module Guard
       super
       @options = {
         :run_on_start => true,
-        :run_on_all => true
+        :run_on_all => true,
+        :failure_ok => false,
       }.update(options)
       @task = @options[:task]
     end
@@ -46,11 +47,12 @@ module Guard
       end
     end
 
-
     def run_rake_task
       UI.info "running #{@task}"
       ::Rake::Task.tasks.each { |t| t.reenable }
       ::Rake::Task[@task].invoke
+    rescue RuntimeError => e
+      raise e unless @options[:failure_ok]
     end
   end
 end


### PR DESCRIPTION
Hi!

I've added this option to allow me to use rake tasks which might fail -- my personal usage is a rake task that runs rdoc coverage -- if the coverage is not 100%, the rake task fails (which is what I want for release tasking and so forth).

This unfortunately results in the exception bubbling up and more or less crashing the guard-rake subsystem -- the first time this runs in guard will be the last, which isn't very great for adding documentation and testing coverage via rake tasks. :)

The option I've added swallows the exception and is off by default, allowing the existing behavior, but allowing me to also specify that a failure is ok here.

Let me know if you have any qualms! Thanks.
