### PR TITLE
Catch exceptions during rake tasks so guard doesn't disable guard-rake.

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -46,11 +46,15 @@ module Guard
       end
     end
 
-
     def run_rake_task
       UI.info "running #{@task}"
       ::Rake::Task.tasks.each { |t| t.reenable }
       ::Rake::Task[@task].invoke
+    rescue Exception => e
+      UI.error "#{self.class.name} failed to run rake task <#{@task}>, exception was:\n\t#{e.class}: #{e.message}"
+      UI.debug "\n#{e.backtrace.join("\n")}"
+
+      throw :task_has_failed
     end
   end
 end


### PR DESCRIPTION
If a rake task failed or raised an exception then Guard would
automatically disable guard-rake meaning that changes for rake tasks
would no longer be fired.  Rather than raise the exception we
`throw :task_has_failed` to match the guard api and log the error.

Based on [joergschiller's fork](https://github.com/joergschiller/guard-rake) of guard-rake.
