### PR TITLE
Run on modifications instead of changes.

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -45,7 +45,7 @@ module Guard
         run_rake_task(paths)
       end
     else
-      def run_on_changes(paths)
+      def run_on_modifications(paths)
         run_rake_task(paths)
       end
     end
@@ -56,7 +56,7 @@ module Guard
       ::Rake::Task[@task].invoke(*@options[:task_args], paths)
 
       Notifier.notify(
-        "watched files: #{paths}", 
+        "watched files: #{paths}",
         :title => "running rake task: #{@task}",
         :image => :success
       )
@@ -73,7 +73,7 @@ module Guard
       ARGV.clear
       ::Rake.application.init
       ::Rake.application.load_rakefile
-      self.class.rakefile_loaded = true      
+      self.class.rakefile_loaded = true
     end
   end
 end


### PR DESCRIPTION
This is basically mimicking changes that have been made to several guard gems already, triggering on modifications instead of changes which leads to faulty behaviour when using vim. (guard/guard#495)

I am not sure if we need to change this in the backward compatibilty branch in rake.rb#L44 as well, I guess probably not.

PS: Oh the cleanup of trailing whitespace was done automatically by vim ;)
