### PR TITLE
Add license to gemspec.

### DIFF
--- a/guard-rake.gemspec
+++ b/guard-rake.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/rubyist/guard-rake'
   s.summary     = %q{Guard for running rake tasks}
   s.description = %q{guard-rake automatically runs Rake tasks from your Rakefile}
+  s.license     = "MIT"
 
   s.add_dependency 'guard'
   s.add_dependency 'rake'


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.