### PR TITLE
Fix multiple runs after multiple watcher invokations

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -51,7 +51,7 @@ module Guard
 
     def run_rake_task(paths=[])
       UI.info "running #{@task}"
-      ::Rake::Task.tasks.each { |t| t.reenable }
+      ::Rake::Task[@task].reenable
       ::Rake::Task[@task].invoke(*@options[:task_args], paths)
 
       Notifier.notify(


### PR DESCRIPTION
See #43 

Given a guard config like this:

```
guard 'rake', task: 'load', run_on_start: false do
  watch(%r{.+})
end
```

Before the behavior was:

* First change of watched file, task is executed once
* Second change of watched file, task is executed twice simultaneously
* Third change of watched file, task is executed thrice simultaneously

The expected new behavior is:

Task is executed once, at every change.