### PR TITLE
Automatically create a Guardfile from Rake tasks

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,7 @@
+guard :shell do
+  
+    watch(%r{^(Rakefile|lib/guard/rake/task.rb)$}) do |m|
+      system("rake guard")
+    end
+  
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require 'bundler/gem_tasks'
+require "guard/rake/task"
+
+Guard::Rake::Task.new
+
+task :guard => ['Rakefile','lib/guard/rake/task.rb']

--- a/guard-rake.gemspec
+++ b/guard-rake.gemspec
@@ -13,11 +13,12 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.add_dependency 'guard'
+  s.add_dependency 'guard-shell'
   s.add_dependency 'rake'
+
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map {|f| File.basename(f) }
   s.require_paths = ['lib']
 end
-

--- a/lib/guard/rake/task.rb
+++ b/lib/guard/rake/task.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'rake/tasklib'
+require 'rake/application'
+require 'erb'
+
+# This file was inspired by https://github.com/troessner/reek/blob/master/lib/reek/rake/task.rb
+module Guard
+  #
+  # Defines a task library for running Guard-Rake.
+  #
+  # @public
+  module Rake
+
+    GUARDFILE_TEMPLATE = <<~HEREDOC
+    guard :shell do
+      <% all_tasks.each do |t, files| %>
+        watch(%r{^(<%= files.join('|') %>)$}) do |m|
+          system("rake <%= t %>")
+        end
+      <% end %>
+      <% if @watch_rakefile %>
+        watch(%r{^Rakefile$}) do |m|
+          system("rake guard")
+        end<% end %>
+    end
+    HEREDOC
+
+    # A Rake task that generates Guardfile from rake tasks.
+    #
+    # Inside your Rakefile:
+    #
+    #   require "guard/rake/task"
+    #
+    #   Guard::Rake::Task.new
+    #
+    # Or, your you want to watch Rakefile as well:
+    #
+    #   Guard::Rake::Task.new do |t|
+    #     t.watch_rakefile = true
+    #   end
+    #
+    # You may define your own ERB template:
+    #
+    #    Guard::Rake::Task.new('guard') do |t|
+    #      t.template=File.read('Guardfile.erb')
+    #    end
+    #
+    # All these code will create a task that can be run with:
+    #
+    #   rake guard
+    #
+    # Examples:
+    #
+    #   rake guard
+    #   rake guard GUARDFILE=Guardfile2.rb      # output to differente file
+    #
+    # @public
+    #
+    class Task < ::Rake::TaskLib
+      # Name of task. Defaults to :guard.
+      # @public
+      attr_writer :name
+
+      # Path to Guardfile.
+      # Setting the GUARDFILE environment variable overrides this.
+      # @public
+      attr_accessor :guardfile
+
+      # Used inside template to generate watch for Rakefile
+      attr_accessor :watch_rakefile
+
+      # The template code, default value is Guard::Rake::GUARDFILE_TEMPLATE
+      attr_accessor :template
+
+      # @public
+      def initialize(name = :guard)
+        @guardfile      = ENV['GUARDFILE'] || 'Guardfile'
+        @name           = name
+        @template       = Guard::Rake::GUARDFILE_TEMPLATE
+
+        yield self if block_given?
+
+        define_task
+      end
+
+      private
+
+
+      def define_task
+        desc "Generates a Guardfile from Rake tasks"
+        task(@name) do
+          all_tasks = {}
+          current_task = nil
+          `rake -P`.each_line do |line|
+            if line.start_with? "rake" then
+              current_task = line.strip
+            else
+              #its a dependency
+              filename = line.strip
+              if File.file?(filename) then
+                all_tasks[current_task] = [] unless all_tasks[current_task]
+                all_tasks[current_task] << filename
+              end
+            end
+          end
+          File.write(guardfile, ERB.new(@template).result(binding))
+        end
+      end
+
+    end
+  end
+end

--- a/lib/guard/rake/task.rb
+++ b/lib/guard/rake/task.rb
@@ -20,65 +20,25 @@ module Guard
           system("rake <%= t %>")
         end
       <% end %>
-      <% if @watch_rakefile %>
-        watch(%r{^Rakefile$}) do |m|
-          system("rake guard")
-        end<% end %>
     end
     HEREDOC
 
-    # A Rake task that generates Guardfile from rake tasks.
-    #
-    # Inside your Rakefile:
-    #
-    #   require "guard/rake/task"
-    #
-    #   Guard::Rake::Task.new
-    #
-    # Or, your you want to watch Rakefile as well:
-    #
-    #   Guard::Rake::Task.new do |t|
-    #     t.watch_rakefile = true
-    #   end
-    #
-    # You may define your own ERB template:
-    #
-    #    Guard::Rake::Task.new('guard') do |t|
-    #      t.template=File.read('Guardfile.erb')
-    #    end
-    #
-    # All these code will create a task that can be run with:
-    #
-    #   rake guard
-    #
-    # Examples:
-    #
-    #   rake guard
-    #   rake guard GUARDFILE=Guardfile2.rb      # output to differente file
-    #
-    # @public
-    #
     class Task < ::Rake::TaskLib
+
       # Name of task. Defaults to :guard.
       # @public
       attr_writer :name
 
-      # Path to Guardfile.
-      # Setting the GUARDFILE environment variable overrides this.
-      # @public
-      attr_accessor :guardfile
-
-      # Used inside template to generate watch for Rakefile
-      attr_accessor :watch_rakefile
-
       # The template code, default value is Guard::Rake::GUARDFILE_TEMPLATE
       attr_accessor :template
 
+      attr_accessor :guardfile
+
       # @public
-      def initialize(name = :guard)
-        @guardfile      = ENV['GUARDFILE'] || 'Guardfile'
+      def initialize(name = 'guard', guardfile='Guardfile')
         @name           = name
         @template       = Guard::Rake::GUARDFILE_TEMPLATE
+        @guardfile      = guardfile
 
         yield self if block_given?
 
@@ -87,15 +47,14 @@ module Guard
 
       private
 
-
       def define_task
-        desc "Generates a Guardfile from Rake tasks"
+        desc "Create Guardfile from rake tasks."
         task(@name) do
           all_tasks = {}
           current_task = nil
           `rake -P`.each_line do |line|
             if line.start_with? "rake" then
-              current_task = line.strip
+              current_task = line[5..-1].strip
             else
               #its a dependency
               filename = line.strip
@@ -105,10 +64,9 @@ module Guard
               end
             end
           end
-          File.write(guardfile, ERB.new(@template).result(binding))
+          File.write(@guardfile, ERB.new(@template).result(binding))
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
this is my way to provide this feature #45

I woukd also update the README with:


## Creating a rake task to generate a `Guardfile`

To make some useful code, you must define rake tasks with **file dependencies**. To make it easy to test, put this code inside your `Rakefile`:

```ruby
files = Rake::FileList.new('*.md')

desc "Create a book"
task 'book' => files do
  sh "cat #{files.join(" ")} > book.txt"
end
```

Now you are ready to use. Put this inside your `Rakefile`:

```ruby
require "guard/rake/task"

Guard::Rake::Task.new
```

Or, your may want to watch `Rakefile` as well:

```ruby
Guard::Rake::Task.new do |t|
  t.watch_rakefile = true
end
```

You may define your own ERB template:

```ruby
Guard::Rake::Task.new('guard') do |t|
 t.template=File.read('Guardfile.erb')
end
```
**NOTE**: You will have to provide you own `Guardfile.erb` for the above code to work.

All these code will create a task that can be run with:

    rake guard

Examples:

    rake guard
    rake guard GUARDFILE=Guardfile2.rb      # output to differente file